### PR TITLE
Write indicator value using JSON wrbuf

### DIFF
--- a/src/marcdisp.c
+++ b/src/marcdisp.c
@@ -1318,8 +1318,9 @@ int yaz_marc_write_json(yaz_marc_t mt, WRBUF w)
                 int i;
                 for (i = 0; n->u.datafield.indicator[i]; i++)
                 {
-                    wrbuf_printf(w, ",\n\t\t\t\t\"ind%d\":\"%c\"", i + 1,
-                                 n->u.datafield.indicator[i]);
+                    wrbuf_printf(w, ",\n\t\t\t\t\"ind%d\":\"", i + 1);
+                    wrbuf_json_write(w, &n->u.datafield.indicator[i], 1);
+                    wrbuf_printf(w, "\"");
                 }
             }
             wrbuf_puts(w, "\n\t\t\t}\n");


### PR DESCRIPTION
We recently received MARCXML with backslashes as the value of some indicators. Gibberish, obviously, but yaz-marcdump was producing invalid JSON as output. This commit runs it through wrbuf_json_write so that the backslash is properly escaped.