### PR TITLE
Fix typos, which show in the Doxygen-generated docs

### DIFF
--- a/doc/book.xml
+++ b/doc/book.xml
@@ -6408,7 +6408,7 @@ cql_transform_t cql_transform_open_FILE (FILE *f);
 cql_transform_t cql_transform_open_fname(const char *fname);
 void cql_transform_close(cql_transform_t ct);
      </synopsis>
-     The first two functions create a tranformation handle from
+     The first two functions create a transformation handle from
      either an already open FILE or from a filename respectively.
      </para>
      <para>

--- a/include/yaz/poll.h
+++ b/include/yaz/poll.h
@@ -27,7 +27,7 @@
 
 /**
  * \file
- * \brief Poll , select wrappers
+ * \brief Poll, select wrappers
  */
 #ifndef YAZ_POLL_H
 #define YAZ_POLL_H

--- a/include/yaz/prt-ext.h
+++ b/include/yaz/prt-ext.h
@@ -27,7 +27,7 @@
 
 /**
  * \file prt-ext.h
- * \brief Header for utilities that handles Z39.50 EXTERNALs
+ * \brief Header for utilities that handle Z39.50 EXTERNALs
  */
 
 /*

--- a/include/yaz/retrieval.h
+++ b/include/yaz/retrieval.h
@@ -27,7 +27,7 @@
 
 /**
  * \file retrieval.h
- * \brief Retrieval Utility
+ * \brief Retrieval utility
  */
 
 #ifndef YAZ_RETRIEVAL_H

--- a/include/yaz/timing.h
+++ b/include/yaz/timing.h
@@ -27,7 +27,7 @@
 
 /**
  * \file timing.h
-   \brief Timing Utilities
+   \brief Timing utilities
 
  */
 

--- a/include/yaz/url.h
+++ b/include/yaz/url.h
@@ -27,7 +27,7 @@
 
 /**
  * \file url.h
- * \brief Fetch URL utility
+ * \brief URL fetch utility
  */
 
 #ifndef YAZ_URL_H

--- a/include/yaz/yaz-util.h
+++ b/include/yaz/yaz-util.h
@@ -55,55 +55,55 @@
     YAZ User's Guide and Reference at
     http://www.indexdata.com/yaz/doc/
     This is also located in the doc directory of the YAZ distribution.
-    (This main page is from yaz-util.h).
+    (This main page is from yaz-util.h)
 
-    The following sections is just a summary of the most important
+    The following sections are just a summary of the most important
     header files and where they belong.
 
-    \section utilities Utilies
-    Logging (syslog-like) utility \ref log.h .
+    \section utilities Utilities
+    Logging (syslog-like) utility \ref log.h
 
-    Memory management for small blocks \ref nmem.h .
+    Memory management for small blocks \ref nmem.h
 
-    Write string buffer \ref wrbuf.h .
+    Write string buffer \ref wrbuf.h
 
-    Options handling \ref options.h .
+    Options handling \ref options.h
 
-    Character conversion \ref yaz-iconv.h .
+    Character conversion \ref yaz-iconv.h
 
-    MARC / MARCXML \ref marcdisp.h .
+    MARC / MARCXML \ref marcdisp.h
 
-    Testing framework: \ref test.h .
+    Testing framework: \ref test.h
 
-    Record conversion: \ref record_conv.h .
+    Record conversion: \ref record_conv.h
 
-    Record retrieval: \ref retrieval.h .
+    Record retrieval: \ref retrieval.h
 
-    Timing : \ref timing.h .
+    Timing : \ref timing.h
 
-    Locking: \ref mutex.h .
+    Locking: \ref mutex.h
 
-    Daemon: \ref daemon.h .
+    Daemon: \ref daemon.h
 
-    Windows Service: \ref sc.h .
+    Windows Service: \ref sc.h
 
     \section queryparsers Query parsers
 
-    PQF parsing: \ref pquery.h .
+    PQF parsing: \ref pquery.h
 
-    CCL parsing: \ref ccl.h .
+    CCL parsing: \ref ccl.h
 
-    CQL parsing and conversion: \ref cql.h .
+    CQL parsing and conversion: \ref cql.h
 
-    Z39.50 sort: \ref sortspec.h .
+    Z39.50 sort: \ref sortspec.h
 
     \section ber BER handling
 
-    BER utilities (ODR): \ref odr.h .
+    BER utilities (ODR): \ref odr.h
 
     \section z3950 Z39.50
 
-    Z39.50 common header: \ref proto.h .
+    Z39.50 common header: \ref proto.h
 
     Z39.50 core codecs: \ref z-core.h.
 
@@ -115,41 +115,41 @@
     \ref z-acckrb1.h ,  \ref z-diag1.h ,
     \ref z-grs.h ,    \ref z-rrf1.h ,   \ref z-uifr1.h
     \ref z-charneg.h ,  \ref z-espec1.h
-    \ref z-mterm2.h , \ref z-rrf2.h ,   \ref z-univ.h .
+    \ref z-mterm2.h , \ref z-rrf2.h ,   \ref z-univ.h
 
     Z39.50 extended services:
     \ref zes-admin.h , \ref zes-exps.h , \ref zes-pquery.h ,
     \ref zes-pset.h , \ref zes-update.h ,
     \ref zes-expi.h , \ref zes-order.h ,  \ref zes-psched.h ,
-    \ref zes-update0.h .
+    \ref zes-update0.h
 
-    Z39.50 diagnostics: \ref diagbib1.h .
+    Z39.50 diagnostics: \ref diagbib1.h
 
-    Z39.50 externals: \ref prt-ext.h .
+    Z39.50 externals: \ref prt-ext.h
 
     \section GDU Generic Data Unit (HTTP and BER)
 
-    Definitions for GDU and HTTP: \ref zgdu.h .
+    Definitions for GDU and HTTP: \ref zgdu.h
 
     \section SRU SRU
 
-    SRU/SRW definitions: \ref srw.h .
+    SRU/SRW definitions: \ref srw.h
 
-    SRW diagnostics: \ref diagsrw.h .
+    SRW diagnostics: \ref diagsrw.h
 
     \section ILL ILL
 
-    Common header: \ref ill.h .
+    Common header: \ref ill.h
 
     Codecs: \ref ill-core.h
 
     \section ZOOM ZOOM
 
-    Common header: \ref zoom.h .
+    Common header: \ref zoom.h
 
     \section GFS Generic Frontend Server (GFS)
 
-    Header: \ref backend.h .
+    Header: \ref backend.h
 
 */
 #endif

--- a/src/marcdisp.c
+++ b/src/marcdisp.c
@@ -46,7 +46,7 @@ enum YAZ_MARC_NODE_TYPE
     YAZ_MARC_LEADER
 };
 
-/** \brief represets a data field */
+/** \brief represents a data field */
 struct yaz_marc_datafield {
     char *tag;
     char *indicator;

--- a/src/mutex-p.h
+++ b/src/mutex-p.h
@@ -27,7 +27,7 @@
 
 /**
  * \file mutex-p.h
- * \brief Declares internal definitinos of for Mutex functions
+ * \brief Declares internal definitions of for Mutex functions
  */
 
 struct yaz_mutex {

--- a/src/record_conv.c
+++ b/src/record_conv.c
@@ -63,7 +63,7 @@ struct marc_info {
     const char *leader_spec;
 };
 
-/** \brief tranformation info (rule info) */
+/** \brief transformation info (rule info) */
 struct yaz_record_conv_rule {
     struct yaz_record_conv_type *type;
     void *info;

--- a/src/session.h
+++ b/src/session.h
@@ -26,7 +26,7 @@
  */
 /**
  * \file session.h
- * \brief Internal Header for GFS.
+ * \brief Internal header for GFS.
  */
 #ifndef SESSION_H
 #define SESSION_H

--- a/src/timing.c
+++ b/src/timing.c
@@ -5,7 +5,7 @@
 
 /**
  * \file timing.c
- * \brief Timing Utilities
+ * \brief Timing utilities
  */
 
 #if HAVE_CONFIG_H

--- a/ztest/dummy-opac.c
+++ b/ztest/dummy-opac.c
@@ -3,7 +3,7 @@
  * See the file LICENSE for details.
  */
 /** \file
- * \brief Little toy-thing to genearate an OPAC record with some values
+ * \brief Little toy-thing to generate an OPAC record with some values
  */
 #if HAVE_CONFIG_H
 #include <config.h>


### PR DESCRIPTION
At this stage, only doing those which show on the front page and the "Files" section of the Doxygen-generated docs.