### PR TITLE
Travis CI: Add dist: xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ sudo: required
 matrix:
   include:
     - os: linux
+      dist: xenial
+      compiler: clang
+      env:
+       - MY_OS=xenial
+    - os: linux
       dist: trusty
       compiler: clang
       env:


### PR DESCRIPTION
__xenial__ is now officially supported by Travis CI: https://blog.travis-ci.com/2018-11-08-xenial-release

Xenial support will be important for any downstream repos that use Python >= 3.7 because Travis CI does not support them on Trusty.  travis-ci/travis-ci#9815