### PR TITLE
Add pkg-config templates for YAZ ICU and YAZ server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ configure
 libtool
 yaz-config
 yaz.pc
+yaz-server.pc
 Doxyfile
 dox
 autom4te.cache

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ configure
 libtool
 yaz-config
 yaz.pc
+yaz-icu.pc
 yaz-server.pc
 Doxyfile
 dox

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,11 +13,11 @@ aclocaldir=$(datadir)/aclocal
 aclocal_DATA = m4/yaz.m4
 
 pkgconfigdir = $(libdir)/pkgconfig
-pkgconfig_DATA = yaz.pc
+pkgconfig_DATA = yaz.pc yaz-server.pc
 
 SPEC_FILE=$(PACKAGE).spec
 EXTRA_DIST=$(SPEC_FILE) IDMETA README.md LICENSE NEWS m4/id-config.sh \
-	yaz-config.in yaz.pc.in m4/yaz.m4 m4/yaz_libxml2.m4 buildconf.sh \
+	yaz-config.in yaz.pc.in yaz-server.pc.in m4/yaz.m4 m4/yaz_libxml2.m4 buildconf.sh \
 	Doxyfile.in m4/acx_pthread.m4 m4/ac_check_icu.m4 m4/common.nsi m4/mk_version.tcl
 
 dist-hook:

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,11 +13,12 @@ aclocaldir=$(datadir)/aclocal
 aclocal_DATA = m4/yaz.m4
 
 pkgconfigdir = $(libdir)/pkgconfig
-pkgconfig_DATA = yaz.pc yaz-server.pc
+pkgconfig_DATA = yaz.pc yaz-icu.pc yaz-server.pc
 
 SPEC_FILE=$(PACKAGE).spec
 EXTRA_DIST=$(SPEC_FILE) IDMETA README.md LICENSE NEWS m4/id-config.sh \
-	yaz-config.in yaz.pc.in yaz-server.pc.in m4/yaz.m4 m4/yaz_libxml2.m4 buildconf.sh \
+	yaz-config.in yaz.pc.in yaz-icu.pc yaz-server.pc.in \
+        m4/yaz.m4 m4/yaz_libxml2.m4 buildconf.sh \
 	Doxyfile.in m4/acx_pthread.m4 m4/ac_check_icu.m4 m4/common.nsi m4/mk_version.tcl
 
 dist-hook:

--- a/configure.ac
+++ b/configure.ac
@@ -413,6 +413,7 @@ doc/common/print.dsl
 etc/Makefile
 yaz-config
 yaz.pc
+yaz-icu.pc
 yaz-server.pc
 Doxyfile
 win/version.nsi

--- a/configure.ac
+++ b/configure.ac
@@ -375,7 +375,7 @@ dnl
 dnl
 AC_CHECK_ICU([3.4],[
 	if test "$xml_enabled" = "true"; then
-	    ICU_CPPFLAGS="$ICU_CPPFLAGS -D YAZ_HAVE_ICU=1"
+	    ICU_CPPFLAGS="$ICU_CPPFLAGS -DYAZ_HAVE_ICU=1"
 	else
 	    ICU_CPPFLAGS=""
 	    AC_MSG_WARN([ICU support disabled because XML support is unavailable])

--- a/configure.ac
+++ b/configure.ac
@@ -413,6 +413,7 @@ doc/common/print.dsl
 etc/Makefile
 yaz-config
 yaz.pc
+yaz-server.pc
 Doxyfile
 win/version.nsi
 include/yaz/yaz-version.h

--- a/yaz-icu.pc.in
+++ b/yaz-icu.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: YAZ ICU
+Version: @VERSION@
+Description: YAZ ICU library for building Z39.50 applications
+Requires: yaz libexslt icu-i18n
+Libs: -L${libdir} -lyaz_icu @PTHREAD_LIBS@
+Cflags: @ICU_CPPFLAGS@

--- a/yaz-server.pc.in
+++ b/yaz-server.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: YAZ server
+Version: @VERSION@
+Description: YAZ server library for building Z39.50 applications
+Requires: yaz libexslt
+Libs: -L${libdir} -lyaz_server @PTHREAD_LIBS@

--- a/yaz.pc.in
+++ b/yaz.pc.in
@@ -5,7 +5,7 @@ includedir=@includedir@
 
 Name: YAZ
 Version: @VERSION@
-Description: YAZ library.
+Description: YAZ library for building Z39.50 applications
 Requires: libexslt
 Libs: -L${libdir} -lyaz
 Libs.private: @LIBS@


### PR DESCRIPTION
Debian is moving to stop packaging `foo-config` legacy scripts in favour of pkg-config, meaning `yaz-config` will not be packaged at some point in the future.

As some downstream packages, such as IDZebra, depend on YAZ ICU and/or YAZ server, I've created pkg-config templates to keep the same functionality, but in pkg-config syntax.