### PR TITLE
Update `make dist` handling

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,9 +17,8 @@ pkgconfig_DATA = yaz.pc yaz-icu.pc yaz-server.pc
 
 SPEC_FILE=$(PACKAGE).spec
 EXTRA_DIST=$(SPEC_FILE) IDMETA README.md LICENSE NEWS m4/id-config.sh \
-	yaz-config.in yaz.pc.in yaz-icu.pc yaz-server.pc.in \
         m4/yaz.m4 m4/yaz_libxml2.m4 buildconf.sh \
-	Doxyfile.in m4/acx_pthread.m4 m4/ac_check_icu.m4 m4/common.nsi m4/mk_version.tcl
+        m4/acx_pthread.m4 m4/ac_check_icu.m4 m4/common.nsi m4/mk_version.tcl
 
 dist-hook:
 	if test -x /usr/bin/git -a -d .git; then git log >ChangeLog ; cp ChangeLog $(distdir); fi

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -6,7 +6,7 @@ SUBDIRS = common
 XMLFILES = book.xml \
  gfs-options.xml gfs-virtual.xml gfs-synopsis.xml \
  std-oid-table.xml  bib1-diag-table.xml srw-diag-table.xml \
- manref.xml local.ent
+ manref.xml
 
 HTMLFILES = index.html
 
@@ -83,13 +83,13 @@ yaz-json-parse.1: yaz-json-parse-man.xml
 yaz-record-conv.1: yaz-record-conv-man.xml
 	$(MAN_COMPILE) $(srcdir)/yaz-record-conv-man.xml
 
-$(HTMLFILES): $(XMLFILES)
+$(HTMLFILES): $(XMLFILES) local.ent
 	rm -f *.html
 	$(HTML_COMPILE) $(srcdir)/book.xml
 
 $(MANFILES): local.ent
 
-yaz.pdf: $(XMLFILES)
+yaz.pdf: $(XMLFILES) local.ent
 	$(PDF_COMPILE) $(srcdir)/book.xml && mv book.pdf yaz.pdf
 
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -83,13 +83,13 @@ yaz-json-parse.1: yaz-json-parse-man.xml
 yaz-record-conv.1: yaz-record-conv-man.xml
 	$(MAN_COMPILE) $(srcdir)/yaz-record-conv-man.xml
 
-$(HTMLFILES): $(XMLFILES) book.xml
+$(HTMLFILES): $(XMLFILES)
 	rm -f *.html
 	$(HTML_COMPILE) $(srcdir)/book.xml
 
 $(MANFILES): local.ent
 
-yaz.pdf: $(XMLFILES) book.xml
+yaz.pdf: $(XMLFILES)
 	$(PDF_COMPILE) $(srcdir)/book.xml && mv book.pdf yaz.pdf
 
 


### PR DESCRIPTION
Some files are being packaged by `make dist` when they shouldn't be. Others, such as `.in`, files are included automatically.

Don't specify `.in` files for packaging by `make dist`. They are included automatically.
Don't package `local.ent`, as it prevents the documentation from being regenerated at build time.