### PR TITLE
Add method alias S_ISREG

### DIFF
--- a/src/xml_include.c
+++ b/src/xml_include.c
@@ -27,6 +27,10 @@
 #include <yaz/log.h>
 #include <yaz/xml_include.h>
 
+#ifdef WIN32
+#define S_ISREG(x) (x & _S_IFREG)
+#endif
+
 #if YAZ_HAVE_XML2
 
 #include <libxml/parser.h>


### PR DESCRIPTION
Yaz 5.33.0 won't build on windows (win\makefile). We get the following error : 

`
xml_include.obj : error LNK2019: symbole externe non résolu S_ISREG référencé dans la fonction config_include_one
..\bin\yaz5.dll : fatal error LNK1120: 1 externes non résolus
`

I had to add an alias for the method "S_ISRESIG' (inspired by a similar piece of code found in many other files).
Not sure if this is the right to proceed but the build succeeds now.

