### PR TITLE
Add TLS handshake retry

### DIFF
--- a/src/tcpip.c
+++ b/src/tcpip.c
@@ -793,7 +793,14 @@ int tcpip_rcvconnect(COMSTACK h)
     }
     if (sp->session)
     {
-        int res = gnutls_handshake(sp->session);
+        // TLS Handshake retry
+        // (see https://www.gnu.org/software/gnutls/reference/gnutls-gnutls.html#gnutls-handshake)
+        int res = GNUTLS_E_AGAIN;
+        int retryCount = 0;
+        while(retryCount++ < 10 && (res == GNUTLS_E_AGAIN || res == GNUTLS_E_INTERRUPTED)) {
+            res = gnutls_handshake(sp->session);
+        }
+
         if (res < 0)
         {
             if (ssl_check_error(h, sp, res))


### PR DESCRIPTION
Fixes a TLS handshake error while querying the following Solr server through Pazpa2 : https://api.archives-ouvertes.fr/search/
Other servers might be concerned too (as TLS moves pretty fast these days)

Solved thanks to the following documentation : https://www.gnu.org/software/gnutls/reference/gnutls-gnutls.html#gnutls-handshake

`
The non-fatal errors such as GNUTLS_E_AGAIN and GNUTLS_E_INTERRUPTED interrupt the handshake procedure, which should be resumed later. Call this function again, until it returns 0;
`

In our case, the first call always returns GNUTLS_E_AGAIN while the second call is successful. Hence the need for a retry strategy.