### PR TITLE
Using xmlReadMemory instead of xmlParseMemory

### DIFF
--- a/src/solr.c
+++ b/src/solr.c
@@ -346,7 +346,7 @@ int yaz_solr_decode_response(ODR o, Z_HTTP_Response *hres, Z_SRW_PDU **pdup)
 #if YAZ_HAVE_XML2
     const char *content_buf = hres->content_buf;
     int content_len = hres->content_len;
-    xmlDocPtr doc = xmlParseMemory(content_buf, content_len);
+    xmlDocPtr doc = xmlReadMemory(content_buf, content_len, NULL, NULL, XML_PARSE_NOBLANKS);
 
     if (doc)
     {


### PR DESCRIPTION
We encountered erros while querying a Solr server through Pazpar2. The problem was linked to empty nodes not being handled in the "yaz_solr_decode_facet_field" method.

Instead of applying the same recipie as found in other methods (testing node->type == XML_ELEMENT_NODE), I've tried to load the document with the XML_PARSE_NOBLANKS option).

This option removes the empty text nodes that happens when the Solr XML response is indented (line feeds).

Naturally, it's up to you to decide what is safer (testing nodes types or loading without blanks). But anyway, we had errors that crashed Pazpar2 with the following Solr server : https://api.archives-ouvertes.fr/search/