### PR TITLE
FIX: fix build error with glibc 2.39

### DIFF
--- a/src/record_conv.c
+++ b/src/record_conv.c
@@ -11,6 +11,7 @@
 #include <config.h>
 #endif
 
+#include <stdlib.h>
 #include <string.h>
 #include <yaz/log.h>
 #include <yaz/yaz-iconv.h>

--- a/src/xmlquery.c
+++ b/src/xmlquery.c
@@ -10,6 +10,7 @@
 #endif
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <assert.h>
 

--- a/test/test_record_conv.c
+++ b/test/test_record_conv.c
@@ -9,6 +9,7 @@
 #include <yaz/record_conv.h>
 #include <yaz/test.h>
 #include <yaz/wrbuf.h>
+#include <stdlib.h>
 #include <string.h>
 #include <yaz/log.h>
 #include <yaz/proto.h>

--- a/test/test_retrieval.c
+++ b/test/test_retrieval.c
@@ -9,6 +9,7 @@
 #include <yaz/retrieval.h>
 #include <yaz/test.h>
 #include <yaz/wrbuf.h>
+#include <stdlib.h>
 #include <string.h>
 #include <yaz/log.h>
 #include <yaz/oid_db.h>


### PR DESCRIPTION
glibc 2.39 does some refactoring for header file inclusion and some additional header inclusion is needed for yaz source.

Closes #104 .