### PR TITLE
Remove pointer to bool conversion warnings

### DIFF
--- a/src/cqltransform.c
+++ b/src/cqltransform.c
@@ -343,7 +343,7 @@ const char *cql_lookup_reverse(cql_transform_t ct,
                     Z_AttributeElement a_ae = *attributes->attributes[j];
                     if (!compare_attr(e_ae, &a_ae))
                         break;
-                    if (a_ae.attributeSet && &e_ae->attributeSet &&
+                    if (a_ae.attributeSet && e_ae->attributeSet &&
                         !oid_oidcmp(a_ae.attributeSet, yaz_oid_attset_bib_1))
                         a_ae.attributeSet = 0;
                     if (!compare_attr(e_ae, &a_ae))
@@ -1046,4 +1046,3 @@ void cql_transform_set_error(cql_transform_t ct, int error, const char *addinfo)
  * End:
  * vim: shiftwidth=4 tabstop=8 expandtab
  */
-

--- a/util/yaz-icu.c
+++ b/util/yaz-icu.c
@@ -564,10 +564,10 @@ int main(int argc, char **argv)
     yaz_enable_panic_backtrace(*argv);
     read_params(argc, argv, &config);
 
-    if (config.conffile && strlen(config.conffile))
+    if (strlen(config.conffile))
         process_text_file(&config);
 
-    if (config.print && strlen(config.print))
+    if (strlen(config.print))
         print_info(&config);
 
     u_cleanup();
@@ -593,4 +593,3 @@ int main(int argc, char **argv)
  * End:
  * vim: shiftwidth=4 tabstop=8 expandtab
  */
-


### PR DESCRIPTION
conffile and print: static array pointer is never null
&e_ae->attributeSet: pointer variable address is never null