### PR TITLE
Fix warn_unused_result warnings produced by gcc/clang

### DIFF
--- a/src/xmalloc.c
+++ b/src/xmalloc.c
@@ -266,7 +266,7 @@ void *xrealloc_f(void *o, size_t size, const char *file, int line)
 
     if (log_level)
         yaz_log(log_level,
-                "%s:%d: xrealloc(s=%ld) %p -> %p", file, line, (long) size, o, p);
+                "%s:%d: xrealloc(s=%ld) %p", file, line, (long) size, p);
     if (!p)
     {
         yaz_log(YLOG_FATAL, "%s:%d: Out of memory, realloc(%ld bytes)",

--- a/ztest/read-marc.c
+++ b/ztest/read-marc.c
@@ -1662,9 +1662,10 @@ char *dummy_xml_record(int num, ODR odr, const char *esn)
             if (stat(wrbuf_cstr(w), &sbuf) == 0 &&
                 (file = fopen(wrbuf_cstr(w), "rb")))
             {
+                size_t r;
                 buf = odr_malloc(odr, 1 + sbuf.st_size);
-                fread(buf, 1, sbuf.st_size, file);
-                buf[sbuf.st_size] = '\0';
+                r = fread(buf, 1, sbuf.st_size, file);
+                buf[r] = '\0';
             }
             if (file)
                 fclose(file);


### PR DESCRIPTION
See #142