### PR TITLE
Only use ubrk_clone for ICU v69 and later

### DIFF
--- a/src/icu_tokenizer.c
+++ b/src/icu_tokenizer.c
@@ -68,7 +68,11 @@ struct icu_tokenizer *icu_tokenizer_clone(struct icu_tokenizer *old)
     assert(old);
     icu_tokenizer_reset(tokenizer, old->action);
     assert(old->bi);
+#if U_ICU_VERSION_MAJOR_NUM >= 69
     tokenizer->bi = ubrk_clone(old->bi, &status);
+#else
+    tokenizer->bi = ubrk_safeClone(old->bi, NULL, &bufferSize, &status);
+#endif
     if (U_SUCCESS(status))
         return tokenizer;
     return tokenizer;


### PR DESCRIPTION
As it is not present in earlier versions (before 69).