### PR TITLE
Include config.h firstly in charconv gen files

### DIFF
--- a/src/charconv.tcl
+++ b/src/charconv.tcl
@@ -15,11 +15,11 @@ proc preamble_trie {ofilehandle ifiles ofile} {
     puts $f ""
     puts $f "    Generated automatically by charconv.tcl"
     puts $f "*/"
-    puts $f "\#include <string.h>"
 
     puts $f "\#if HAVE_CONFIG_H"
     puts $f "\#include <config.h>"
     puts $f "\#endif"
+    puts $f "\#include <string.h>"
 
     puts $f "
         struct yaz_iconv_trie_flat {


### PR DESCRIPTION
Fixes _POSIX_C_SOURCE being redefined.