### PR TITLE
Add MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,1 @@
+bazel_dep(name = "rules_cc", version = "0.2.17")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,1 +1,0 @@
-workspace(name = "yaz")


### PR DESCRIPTION
Since Bazel version 8, WORKSPACE is no longer read by default.