### PR TITLE
Add cs_get_error

### DIFF
--- a/client/client.c
+++ b/client/client.c
@@ -288,20 +288,6 @@ static void print_comstack_error(const char *operation, COMSTACK cs)
     fprintf(stderr, "\n");
 }
 
-static void log_comstack_error(const char *operation, const char *uri,
-                               COMSTACK cs)
-{
-    const char *details = 0;
-    int code = cs_get_error(cs, &details);
-
-    if (details)
-        yaz_log(YLOG_WARN, "%s URL:%s: cs=%d msg=%s details=%s",
-                operation, uri, code, cs_errmsg(code), details);
-    else
-        yaz_log(YLOG_WARN, "%s URL:%s: cs=%d msg=%s",
-                operation, uri, code, cs_errmsg(code));
-}
-
 int send_apdu(Z_APDU *a)
 {
     char *buf;
@@ -2766,7 +2752,7 @@ static WRBUF get_url(const char *uri, WRBUF username, WRBUF password,
                       "text/xml");
     if (!z_GDU(out, &gdu, 0, 0))
     {
-        yaz_log(YLOG_WARN, "Can not encode HTTP request URL:%s", uri);
+        fprintf(stderr, "Can not encode HTTP request URL:%s\n", uri);
     }
     else
     {
@@ -2774,10 +2760,10 @@ static WRBUF get_url(const char *uri, WRBUF username, WRBUF password,
         int cs_flags = CS_FLAGS_BLOCKING | (check_cert ? CS_FLAGS_CHECK_CERT : 0);
         COMSTACK conn = cs_create_host(uri, cs_flags, &add);
         if (!conn)
-            yaz_log(YLOG_WARN, "Can not create connection for URL:%s", uri);
+            fprintf(stderr, "Can not create connection for URL:%s\n", uri);
         else if (cs_connect(conn, add) < 0)
         {
-            log_comstack_error("Can not connect to", uri, conn);
+            print_comstack_error("Can not connect", conn);
             cs_close(conn);
         }
         else
@@ -2786,7 +2772,7 @@ static WRBUF get_url(const char *uri, WRBUF username, WRBUF password,
             char *buf = odr_getbuf(out, &len, 0);
 
             if (cs_put(conn, buf, len) < 0)
-                log_comstack_error("cs_put failed", uri, conn);
+                print_comstack_error("cs_put failed", conn);
             else
             {
                 char *netbuffer = 0;
@@ -2795,10 +2781,10 @@ static WRBUF get_url(const char *uri, WRBUF username, WRBUF password,
                 if (res <= 0)
                 {
                     if (res < 0)
-                        log_comstack_error("cs_get failed", uri, conn);
+                        print_comstack_error("cs_get failed", conn);
                     else
-                        yaz_log(YLOG_WARN,
-                                "Connection closed while reading URL:%s",
+                        fprintf(stderr,
+                                "Connection closed while reading URL:%s\n",
                                 uri);
                 }
                 else
@@ -2808,7 +2794,7 @@ static WRBUF get_url(const char *uri, WRBUF username, WRBUF password,
                     if (!z_GDU(in, &gdu, 0, 0)
                         || gdu->which != Z_GDU_HTTP_Response)
                     {
-                        yaz_log(YLOG_WARN, "decode failed URL: %s", uri);
+                        fprintf(stderr, "decode failed URL: %s\n", uri);
                     }
                     else
                     {

--- a/client/client.c
+++ b/client/client.c
@@ -277,6 +277,31 @@ static void add_otherInfos(Z_APDU *a)
     }
 }
 
+static void print_comstack_error(const char *operation, COMSTACK cs)
+{
+    const char *details = 0;
+    int code = cs_get_error(cs, &details);
+
+    fprintf(stderr, "%s: cs=%d msg=%s", operation, code, cs_errmsg(code));
+    if (details)
+        fprintf(stderr, " details=%s", details);
+    fprintf(stderr, "\n");
+}
+
+static void log_comstack_error(const char *operation, const char *uri,
+                               COMSTACK cs)
+{
+    const char *details = 0;
+    int code = cs_get_error(cs, &details);
+
+    if (details)
+        yaz_log(YLOG_WARN, "%s URL:%s: cs=%d msg=%s details=%s",
+                operation, uri, code, cs_errmsg(code), details);
+    else
+        yaz_log(YLOG_WARN, "%s URL:%s: cs=%d msg=%s",
+                operation, uri, code, cs_errmsg(code));
+}
+
 int send_apdu(Z_APDU *a)
 {
     char *buf;
@@ -301,7 +326,7 @@ int send_apdu(Z_APDU *a)
     do_hex_dump(buf, len);
     if (cs_put(conn, buf, len) < 0)
     {
-        fprintf(stderr, "cs_put: %s\n", cs_errmsg(cs_errno(conn)));
+        print_comstack_error("cs_put", conn);
         close_session();
         return 0;
     }
@@ -736,7 +761,7 @@ static int session_connect_base(const char *arg, const char **basep)
     fflush(stdout);
     if (cs_connect(conn, add) < 0)
     {
-        printf("error = %s\n", cs_strerror(conn));
+        print_comstack_error("connect failed", conn);
         cs_close(conn);
         conn = 0;
         return 0;
@@ -1322,6 +1347,7 @@ static int send_gdu(Z_GDU *gdu)
 
         if (r >= 0)
             return 2;
+        print_comstack_error("cs_put", conn);
     }
     return 0;
 }
@@ -2747,15 +2773,17 @@ static WRBUF get_url(const char *uri, WRBUF username, WRBUF password,
         void *add;
         int cs_flags = CS_FLAGS_BLOCKING | (check_cert ? CS_FLAGS_CHECK_CERT : 0);
         COMSTACK conn = cs_create_host(uri, cs_flags, &add);
-        if (cs_connect(conn, add) < 0)
-            yaz_log(YLOG_WARN, "Can not connect to URL:%s", uri);
+        if (!conn)
+            yaz_log(YLOG_WARN, "Can not create connection for URL:%s", uri);
+        else if (cs_connect(conn, add) < 0)
+            log_comstack_error("Can not connect to", uri, conn);
         else
         {
             int len;
             char *buf = odr_getbuf(out, &len, 0);
 
             if (cs_put(conn, buf, len) < 0)
-                yaz_log(YLOG_WARN, "cs_put failed URL:%s", uri);
+                log_comstack_error("cs_put failed", uri, conn);
             else
             {
                 char *netbuffer = 0;
@@ -2763,7 +2791,12 @@ static WRBUF get_url(const char *uri, WRBUF username, WRBUF password,
                 int res = cs_get(conn, &netbuffer, &netlen);
                 if (res <= 0)
                 {
-                    yaz_log(YLOG_WARN, "cs_get failed URL:%s", uri);
+                    if (res < 0)
+                        log_comstack_error("cs_get failed", uri, conn);
+                    else
+                        yaz_log(YLOG_WARN,
+                                "Connection closed while reading URL:%s",
+                                uri);
                 }
                 else
                 {
@@ -4554,6 +4587,8 @@ static void wait_and_handle_response(int one_response_only)
         res = cs_get(conn, &netbuffer, &netbufferlen);
         if (res <= 0)
         {
+            if (res < 0)
+                print_comstack_error("cs_get", conn);
             if (reconnect_ok && protocol == PROTO_HTTP)
             {
                 cs_close(conn);
@@ -4566,7 +4601,12 @@ static void wait_and_handle_response(int one_response_only)
                     int len_out;
                     buf_out = odr_getbuf(out, &len_out, 0);
                     do_hex_dump(buf_out, len_out);
-                    cs_put(conn, buf_out, len_out);
+                    if (cs_put(conn, buf_out, len_out) < 0)
+                    {
+                        print_comstack_error("cs_put", conn);
+                        close_session();
+                        break;
+                    }
                     odr_reset(out);
                     continue;
                 }
@@ -4603,7 +4643,12 @@ static void wait_and_handle_response(int one_response_only)
                     int len_out;
                     buf_out = odr_getbuf(out, &len_out, 0);
                     do_hex_dump(buf_out, len_out);
-                    cs_put(conn, buf_out, len_out);
+                    if (cs_put(conn, buf_out, len_out) < 0)
+                    {
+                        print_comstack_error("cs_put", conn);
+                        close_session();
+                        break;
+                    }
                     odr_reset(out);
                     continue;
                 }

--- a/client/client.c
+++ b/client/client.c
@@ -2776,7 +2776,10 @@ static WRBUF get_url(const char *uri, WRBUF username, WRBUF password,
         if (!conn)
             yaz_log(YLOG_WARN, "Can not create connection for URL:%s", uri);
         else if (cs_connect(conn, add) < 0)
+        {
             log_comstack_error("Can not connect to", uri, conn);
+            cs_close(conn);
+        }
         else
         {
             int len;

--- a/doc/book.xml
+++ b/doc/book.xml
@@ -9891,13 +9891,6 @@ void odr_choice_bias(ODR o, int what);
    <synopsis>
     int cs_get_error(COMSTACK h, const char **details);
    </synopsis>
-   <para>
-    COMSTACK implementations can set both the error code and its additional
-    information with <function>cs_set_error</function>.
-   </para>
-   <synopsis>
-    void cs_set_error(COMSTACK h, int error, const char *details);
-   </synopsis>
   </sect1>
   <sect1 id="comstack.summary">
    <title>Summary and Synopsis</title>
@@ -9935,8 +9928,6 @@ void odr_choice_bias(ODR o, int what);
     int cs_look(COMSTACK handle);
 
     int cs_get_error(COMSTACK handle, const char **details);
-
-    void cs_set_error(COMSTACK handle, int error, const char *details);
 
     void *cs_straddr(COMSTACK handle, const char *str);
 

--- a/doc/book.xml
+++ b/doc/book.xml
@@ -9880,6 +9880,24 @@ void odr_choice_bias(ODR o, int what);
    <synopsis>
     const char *cs_strerror(COMSTACK h);
    </synopsis>
+   <para>
+    Additional information about the current error can be retrieved with
+    <function>cs_get_error</function>. The returned string is owned by the
+    COMSTACK and remains valid until the error is changed or the COMSTACK is
+    closed. If no additional information is available,
+    <literal>*details</literal> is set to null. The function also returns the
+    current error code.
+   </para>
+   <synopsis>
+    int cs_get_error(COMSTACK h, const char **details);
+   </synopsis>
+   <para>
+    COMSTACK implementations can set both the error code and its additional
+    information with <function>cs_set_error</function>.
+   </para>
+   <synopsis>
+    void cs_set_error(COMSTACK h, int error, const char *details);
+   </synopsis>
   </sect1>
   <sect1 id="comstack.summary">
    <title>Summary and Synopsis</title>
@@ -9915,6 +9933,10 @@ void odr_choice_bias(ODR o, int what);
     void cs_close(COMSTACK handle);
 
     int cs_look(COMSTACK handle);
+
+    int cs_get_error(COMSTACK handle, const char **details);
+
+    void cs_set_error(COMSTACK handle, int error, const char *details);
 
     void *cs_straddr(COMSTACK handle, const char *str);
 

--- a/src/BUILD
+++ b/src/BUILD
@@ -230,7 +230,7 @@ cc_library(
 	 "dirent", "mutex", "condvar", "thread_id", "gettimeofday",
 	 "thread_create", "spipe", "url", "backtrace"
 	 ])
-	 + h_dir(".", ["cclp", "iconv-p", "mime", "mutex-p",
+	 + h_dir(".", ["cclp", "comstack-p", "iconv-p", "mime", "mutex-p",
 	   "odr-priv", "sru-p", "zoom-p", "config", "diag-entry"
 	 ])
 	 ,

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -120,7 +120,7 @@ libyaz_la_SOURCES= $(GEN_FILES) \
   odr_seq.c odr_oct.c ber_oct.c odr_bit.c ber_bit.c odr_oid.c \
   ber_oid.c odr_use.c odr_choice.c odr_any.c ber_any.c odr.c odr_mem.c \
   dumpber.c odr_enum.c odr-priv.h \
-  comstack.c tcpip.c unix.c \
+  comstack.c comstack-p.h tcpip.c unix.c \
   prt-ext.c \
   proxunit.c \
   ill-get.c \

--- a/src/comstack-p.h
+++ b/src/comstack-p.h
@@ -1,0 +1,52 @@
+/* This file is part of the YAZ toolkit.
+ * Copyright (C) Index Data.
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Index Data nor the names of its contributors
+ *       may be used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE REGENTS AND CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \file comstack-p.h
+ * \brief Private Header for COMSTACK
+ */
+
+#ifndef COMSTACK_P_H
+#define COMSTACK_P_H
+
+#include <yaz/comstack.h>
+
+YAZ_BEGIN_CDECL
+
+const char *yaz_tcpip_get_error_details(COMSTACK cs);
+
+YAZ_END_CDECL
+
+#endif
+/*
+ * Local variables:
+ * c-basic-offset: 4
+ * c-file-style: "Stroustrup"
+ * indent-tabs-mode: nil
+ * End:
+ * vim: shiftwidth=4 tabstop=8 expandtab
+ */

--- a/src/comstack.c
+++ b/src/comstack.c
@@ -16,7 +16,7 @@
 
 #include <yaz/yaz-iconv.h>
 #include <yaz/log.h>
-#include <yaz/comstack.h>
+#include "comstack-p.h"
 #include <yaz/tcpip.h>
 #include <yaz/unix.h>
 #include <yaz/odr.h>
@@ -51,17 +51,8 @@ const char *cs_strerror(COMSTACK h)
 int cs_get_error(COMSTACK cs, const char **details)
 {
     if (details)
-        *details = wrbuf_len(cs->error_details) ?
-            wrbuf_cstr(cs->error_details) : 0;
+        *details = yaz_tcpip_get_error_details(cs);
     return cs->cerrno;
-}
-
-void cs_set_error(COMSTACK cs, int error, const char *details)
-{
-    wrbuf_rewind(cs->error_details);
-    if (details)
-        wrbuf_puts(cs->error_details, details);
-    cs->cerrno = error;
 }
 
 void cs_get_host_args(const char *type_and_host, const char **args)

--- a/src/comstack.c
+++ b/src/comstack.c
@@ -48,6 +48,22 @@ const char *cs_strerror(COMSTACK h)
     return cs_errmsg(h->cerrno);
 }
 
+int cs_get_error(COMSTACK cs, const char **details)
+{
+    if (details)
+        *details = wrbuf_len(cs->error_details) ?
+            wrbuf_cstr(cs->error_details) : 0;
+    return cs->cerrno;
+}
+
+void cs_set_error(COMSTACK cs, int error, const char *details)
+{
+    wrbuf_rewind(cs->error_details);
+    if (details)
+        wrbuf_puts(cs->error_details, details);
+    cs->cerrno = error;
+}
+
 void cs_get_host_args(const char *type_and_host, const char **args)
 {
     *args = "";
@@ -470,4 +486,3 @@ void cs_set_max_recv_bytes(COMSTACK cs, int max_recv_bytes)
  * End:
  * vim: shiftwidth=4 tabstop=8 expandtab
  */
-

--- a/src/statserv.c
+++ b/src/statserv.c
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdarg.h>
 
 #ifdef WIN32
 #include <process.h>

--- a/src/statserv.c
+++ b/src/statserv.c
@@ -132,6 +132,25 @@ static int log_session = 0; /* one-line logs for session */
 static int log_sessiondetail = 0; /* more detailed stuff */
 static int log_server = 0;
 
+static void log_comstack_error(int level, COMSTACK cs, const char *fmt, ...)
+{
+    char message[512];
+    const char *details = 0;
+    int code = cs_get_error(cs, &details);
+    va_list ap;
+
+    va_start(ap, fmt);
+    yaz_vsnprintf(message, sizeof(message), fmt, ap);
+    va_end(ap);
+
+    if (details)
+        yaz_log(level, "%s: cs=%d msg=%s details=%s",
+                message, code, cs_errmsg(code), details);
+    else
+        yaz_log(level, "%s: cs=%d msg=%s",
+                message, code, cs_errmsg(code));
+}
+
 /** get_logbits sets global loglevel bits */
 static void get_logbits(int force)
 { /* needs to be called after parsing cmd-line args that can set loglevels!*/
@@ -857,7 +876,8 @@ static void listener(IOCHAN h, int event)
 
         if ((res = cs_listen(line, 0, 0)) < 0)
         {
-            yaz_log(YLOG_FATAL|YLOG_ERRNO, "cs_listen failed");
+            log_comstack_error(YLOG_FATAL|YLOG_ERRNO, line,
+                               "cs_listen failed");
             return;
         }
         else if (res == 1)
@@ -866,7 +886,7 @@ static void listener(IOCHAN h, int event)
         new_line = cs_accept(line);
         if (!new_line)
         {
-            yaz_log(YLOG_FATAL, "Accept failed.");
+            log_comstack_error(YLOG_FATAL, line, "Accept failed");
             return;
         }
         yaz_log(YLOG_DEBUG, "Accept ok");
@@ -955,7 +975,8 @@ static void listener(IOCHAN h, int event)
         if ((res = cs_listen_check(line, 0, 0, control_block.check_ip,
                                    control_block.daemon_name)) < 0)
         {
-            yaz_log(YLOG_WARN|YLOG_ERRNO, "cs_listen failed");
+            log_comstack_error(YLOG_WARN|YLOG_ERRNO, line,
+                               "cs_listen failed");
             return;
         }
         else if (res == 1)
@@ -966,7 +987,7 @@ static void listener(IOCHAN h, int event)
         new_line = cs_accept(line);
         if (!new_line)
         {
-            yaz_log(YLOG_FATAL, "Accept failed.");
+            log_comstack_error(YLOG_FATAL, line, "Accept failed");
             iochan_setflags(h, EVENT_INPUT | EVENT_EXCEPT); /* reset listener */
             return;
         }
@@ -1170,11 +1191,11 @@ static int add_listener(char *where, int listen_id)
 
     if (cs_bind(l, ap, CS_SERVER) < 0)
     {
+        int level = YLOG_FATAL;
+
         if (cs_errno(l) == CSYSERR)
-            yaz_log(YLOG_FATAL|YLOG_ERRNO, "Failed to bind to %s", where);
-        else
-            yaz_log(YLOG_FATAL, "Failed to bind to %s: %s", where,
-                    cs_strerror(l));
+            level |= YLOG_ERRNO;
+        log_comstack_error(level, l, "Failed to bind to %s", where);
         cs_close(l);
         return -1;
     }
@@ -1532,4 +1553,3 @@ int statserv_main(int argc, char **argv,
  * End:
  * vim: shiftwidth=4 tabstop=8 expandtab
  */
-

--- a/src/tcpip.c
+++ b/src/tcpip.c
@@ -62,7 +62,7 @@
 #endif
 
 #include <yaz/base64.h>
-#include <yaz/comstack.h>
+#include "comstack-p.h"
 #include <yaz/errno.h>
 #include <yaz/tcpip.h>
 #include <yaz/snprintf.h>
@@ -145,6 +145,7 @@ typedef struct tcpip_state
     WRBUF connect_request;
     char *connect_response_buf;
     int connect_response_len;
+    WRBUF error_details; /* additional information for the current error */
 } tcpip_state;
 
 static int log_level = 0;
@@ -206,7 +207,20 @@ static struct tcpip_state *tcpip_state_create(void)
     sp->connect_request = 0;
     sp->connect_response_buf = 0;
     sp->connect_response_len = 0;
+    sp->error_details = wrbuf_alloc();
     return sp;
+}
+
+static void tcpip_state_destroy(tcpip_state *sp)
+{
+    if (sp->ai)
+        freeaddrinfo(sp->ai);
+    xfree(sp->host_port);
+    xfree(sp->connect_host);
+    wrbuf_destroy(sp->connect_request);
+    xfree(sp->connect_response_buf);
+    wrbuf_destroy(sp->error_details);
+    xfree(sp);
 }
 
 /*
@@ -248,11 +262,19 @@ COMSTACK tcpip_type(int s, int flags, int protocol, void *vp)
     p->event = CS_NONE;
     p->cerrno = 0;
     p->user = 0;
-    p->error_details = wrbuf_alloc();
 
     yaz_log(log_level, "Created TCP/SSL comstack h=%p", p);
 
     return p;
+}
+
+static void cs_set_error(COMSTACK cs, int error, const char *details)
+{
+    struct tcpip_state *sp = (struct tcpip_state *) cs->cprivate;
+    wrbuf_rewind(sp->error_details);
+    if (details)
+        wrbuf_puts(sp->error_details, details);
+    cs->cerrno = error;
 }
 
 static void connect_and_bind(COMSTACK p,
@@ -1086,7 +1108,6 @@ COMSTACK tcpip_accept(COMSTACK h)
         cnew = (COMSTACK) xmalloc(sizeof(*cnew));
 
         memcpy(cnew, h, sizeof(*h));
-        cnew->error_details = wrbuf_alloc();
         cnew->iofile = h->newfd;
         cnew->io_pending = 0;
         cnew->cprivate = state;
@@ -1103,8 +1124,7 @@ COMSTACK tcpip_accept(COMSTACK h)
 #endif
                 h->newfd = -1;
             }
-            xfree(state);
-            wrbuf_destroy(cnew->error_details);
+            tcpip_state_destroy(state);
             xfree(cnew);
             return 0;
         }
@@ -1122,17 +1142,15 @@ COMSTACK tcpip_accept(COMSTACK h)
             gnutls_init(&state->session, GNUTLS_SERVER);
             if (!state->session)
             {
-                wrbuf_destroy(cnew->error_details);
+                tcpip_state_destroy(state);
                 xfree(cnew);
-                xfree(state);
                 return 0;
             }
             res = gnutls_set_default_priority(state->session);
             if (res != GNUTLS_E_SUCCESS)
             {
-                wrbuf_destroy(cnew->error_details);
+                tcpip_state_destroy(state);
                 xfree(cnew);
-                xfree(state);
                 return 0;
             }
             res = gnutls_credentials_set(state->session,
@@ -1140,9 +1158,8 @@ COMSTACK tcpip_accept(COMSTACK h)
                                          st->cred_ptr->xcred);
             if (res != GNUTLS_E_SUCCESS)
             {
-                wrbuf_destroy(cnew->error_details);
+                tcpip_state_destroy(state);
                 xfree(cnew);
-                xfree(state);
                 return 0;
             }
             SET_GNUTLS_SOCKET(state->session, cnew->iofile);
@@ -1486,14 +1503,7 @@ void tcpip_close(COMSTACK h)
     }
     tcpip_release_cred(&sp->cred_ptr);
 #endif
-    if (sp->ai)
-        freeaddrinfo(sp->ai);
-    xfree(sp->host_port);
-    xfree(sp->connect_host);
-    wrbuf_destroy(sp->connect_request);
-    xfree(sp->connect_response_buf);
-    xfree(sp);
-    wrbuf_destroy(h->error_details);
+    tcpip_state_destroy(sp);
     xfree(h);
 }
 
@@ -1778,6 +1788,18 @@ int cs_set_head_only(COMSTACK cs, int head_only)
     cs_set_error(cs, CS_ST_INCON, 0);
     return -1;
 }
+
+const char *yaz_tcpip_get_error_details(COMSTACK cs)
+{
+    if (cs->type == tcpip_type || cs->type == ssl_type)
+    {
+        tcpip_state *sp = (tcpip_state *)cs->cprivate;
+        if (wrbuf_len(sp->error_details))
+            return wrbuf_cstr(sp->error_details);
+    }
+    return 0;
+}
+
 
 /*
  * Local variables:

--- a/src/tcpip.c
+++ b/src/tcpip.c
@@ -537,7 +537,7 @@ static struct addrinfo *create_net_socket(COMSTACK h)
         if (setsockopt(h->iofile, SOL_SOCKET, SO_REUSEADDR, (char*)
                        &one, sizeof(one)) < 0)
         {
-            h->cerrno = CSYSERR;
+            cs_set_error(h, CSYSERR, 0);
             return 0;
         }
 #endif
@@ -555,7 +555,7 @@ static struct addrinfo *create_net_socket(COMSTACK h)
         }
         if (r)
         {
-            h->cerrno = CSYSERR;
+            cs_set_error(h, CSYSERR, 0);
             freeaddrinfo(ai);
             return 0;
         }
@@ -677,7 +677,7 @@ static int cont_connect(COMSTACK h)
             return tcpip_connect(h, ai);
         }
     }
-    h->cerrno = CSYSERR;
+    cs_set_error(h, CSYSERR, 0);
     return -1;
 }
 
@@ -696,7 +696,7 @@ int tcpip_connect(COMSTACK h, void *address)
     h->io_pending = 0;
     if (h->state != CS_ST_UNBND)
     {
-        h->cerrno = CSOUTSTATE;
+        cs_set_error(h, CSOUTSTATE, 0);
         return -1;
     }
 #if RESOLVER_THREAD
@@ -806,7 +806,7 @@ int tcpip_rcvconnect(COMSTACK h)
 #endif
     if (h->state != CS_ST_CONNECTING)
     {
-        h->cerrno = CSOUTSTATE;
+        cs_set_error(h, CSOUTSTATE, 0);
         return -1;
     }
     if (sp->connect_host)
@@ -836,13 +836,13 @@ int tcpip_rcvconnect(COMSTACK h)
             if (!yaz_decode_http_response_first(sp->connect_response_buf, sp->connect_response_len, &code, 0, 0, 0, 0))
             {
                 yaz_log(log_level, "tcpip_rcvconnect connect failed: bad response");
-                h->cerrno = CSPROTERR;
+                cs_set_error(h, CSPROTERR, 0);
                 return -1;
             }
             if (code != 200)
             {
                 yaz_log(log_level, "tcpip_rcvconnect connect failed: status %d", code);
-                h->cerrno = CSDENY;
+                cs_set_error(h, CSDENY, 0);
                 return -1;
             }
             sp->complete = cs_complete_auto;
@@ -976,7 +976,7 @@ static int tcpip_bind(COMSTACK h, void *address, int mode)
     if (setsockopt(h->iofile, SOL_SOCKET, SO_REUSEADDR, (char*)
         &one, sizeof(one)) < 0)
     {
-        h->cerrno = CSYSERR;
+        cs_set_error(h, CSYSERR, 0);
         return -1;
     }
 #endif
@@ -985,13 +985,13 @@ static int tcpip_bind(COMSTACK h, void *address, int mode)
     sp->ai = 0;
     if (r)
     {
-        h->cerrno = CSYSERR;
+        cs_set_error(h, CSYSERR, 0);
         return -1;
     }
     /* Allow a maximum-sized backlog of waiting-to-connect clients */
     if (mode == CS_SERVER && listen(h->iofile, SOMAXCONN) < 0)
     {
-        h->cerrno = CSYSERR;
+        cs_set_error(h, CSYSERR, 0);
         return -1;
     }
     h->state = CS_ST_IDLE;
@@ -1013,7 +1013,7 @@ int tcpip_listen(COMSTACK h, char *raddr, int *addrlen,
     yaz_log(log_level, "tcpip_listen h=%p", h);
     if (h->state != CS_ST_IDLE)
     {
-        h->cerrno = CSOUTSTATE;
+        cs_set_error(h, CSOUTSTATE, 0);
         return -1;
     }
 #ifdef WIN32
@@ -1035,12 +1035,12 @@ int tcpip_listen(COMSTACK h, char *raddr, int *addrlen,
 #endif
 #endif
             )
-            h->cerrno = CSNODATA;
+            cs_set_error(h, CSNODATA, 0);
         else
         {
             shutdown(h->iofile, 0); /* SHUT_RD/SHUT_RECEIVE */
             listen(h->iofile, SOMAXCONN);
-            h->cerrno = CSYSERR;
+            cs_set_error(h, CSYSERR, 0);
         }
         return -1;
     }
@@ -1055,7 +1055,7 @@ int tcpip_listen(COMSTACK h, char *raddr, int *addrlen,
     if (check_ip && (*check_ip)(cd, (const char *) &addr,
         sizeof(addr), AF_INET))
     {
-        h->cerrno = CSDENY;
+        cs_set_error(h, CSDENY, 0);
 #ifdef WIN32
         closesocket(h->newfd);
 #else
@@ -1093,7 +1093,7 @@ COMSTACK tcpip_accept(COMSTACK h)
 
         if (!tcpip_set_blocking(cnew, cnew->flags))
         {
-            h->cerrno = CSYSERR;
+            cs_set_error(h, CSYSERR, 0);
             if (h->newfd != -1)
             {
 #ifdef WIN32
@@ -1173,7 +1173,7 @@ COMSTACK tcpip_accept(COMSTACK h)
     }
     else
     {
-        h->cerrno = CSOUTSTATE;
+        cs_set_error(h, CSOUTSTATE, 0);
         return 0;
     }
     h->io_pending = 0;
@@ -1215,7 +1215,7 @@ int tcpip_get(COMSTACK h, char **buf, int *bufsize)
         {
             if (!(*buf = (char *)xmalloc(*bufsize = CS_TCPIP_BUFCHUNK)))
             {
-                h->cerrno = CSYSERR;
+                cs_set_error(h, CSYSERR, 0);
                 return -1;
             }
         }
@@ -1227,12 +1227,12 @@ int tcpip_get(COMSTACK h, char **buf, int *bufsize)
                 *bufsize = *bufsize * 2;
             if (*bufsize - hasread < CS_TCPIP_BUFCHUNK)
             {
-                h->cerrno = CSBUFSIZE;
+                cs_set_error(h, CSBUFSIZE, 0);
                 return -1;
             }
             if (!(*buf = (char *)xrealloc(*buf, *bufsize)))
             {
-                h->cerrno = CSYSERR;
+                cs_set_error(h, CSYSERR, 0);
                 return -1;
             }
         }
@@ -1279,7 +1279,7 @@ int tcpip_get(COMSTACK h, char **buf, int *bufsize)
                 }
                 else
                 {
-                    h->cerrno = CSYSERR;
+                    cs_set_error(h, CSYSERR, 0);
                     return -1;
                 }
 #else
@@ -1302,7 +1302,7 @@ int tcpip_get(COMSTACK h, char **buf, int *bufsize)
                     continue;
                 else
                 {
-                    h->cerrno = CSYSERR;
+                    cs_set_error(h, CSYSERR, 0);
                     return -1;
                 }
 #endif
@@ -1313,13 +1313,13 @@ int tcpip_get(COMSTACK h, char **buf, int *bufsize)
         hasread += res;
         if (hasread > h->max_recv_bytes)
         {
-            h->cerrno = CSBUFSIZE;
+            cs_set_error(h, CSBUFSIZE, 0);
             return -1;
         }
     }
     if (berlen < 0)
     {
-        h->cerrno = CSPROTERR;
+        cs_set_error(h, CSPROTERR, 0);
         return -1;
     }
     yaz_log(log_level, "  Out of read loop with hasread=%d, berlen=%d",
@@ -1335,13 +1335,13 @@ int tcpip_get(COMSTACK h, char **buf, int *bufsize)
         {
             if (!(sp->altbuf = (char *)xmalloc(sp->altsize = req)))
             {
-                h->cerrno = CSYSERR;
+                cs_set_error(h, CSYSERR, 0);
                 return -1;
             }
         } else if (sp->altsize < req)
             if (!(sp->altbuf =(char *)xrealloc(sp->altbuf, sp->altsize = req)))
             {
-                h->cerrno = CSYSERR;
+                cs_set_error(h, CSYSERR, 0);
                 return -1;
             }
         yaz_log(log_level, "  Moving %d bytes to altbuf(%p)", tomove,
@@ -1374,7 +1374,7 @@ int tcpip_put(COMSTACK h, char *buf, int size)
     }
     else if (state->towrite != size)
     {
-        h->cerrno = CSWRONGBUF;
+        cs_set_error(h, CSWRONGBUF, 0);
         return -1;
     }
     while (state->towrite > state->written)
@@ -1431,7 +1431,7 @@ int tcpip_put(COMSTACK h, char *buf, int size)
                 }
                 if (h->flags & CS_FLAGS_BLOCKING)
                 {
-                    h->cerrno = CSYSERR;
+                    cs_set_error(h, CSYSERR, 0);
                     return -1;
                 }
                 else
@@ -1508,7 +1508,7 @@ const char *tcpip_addrstr(COMSTACK h)
 
     if (getpeername(h->iofile, (struct sockaddr *)&addr, &len) < 0)
     {
-        h->cerrno = CSYSERR;
+        cs_set_error(h, CSYSERR, 0);
         return 0;
     }
     if (getnameinfo((struct sockaddr *) &addr, len, host, sizeof(host)-1,
@@ -1775,7 +1775,7 @@ int cs_set_head_only(COMSTACK cs, int head_only)
             sp->complete = cs_complete_auto;
         return 0;
     }
-    cs->cerrno = CS_ST_INCON;
+    cs_set_error(cs, CS_ST_INCON, 0);
     return -1;
 }
 

--- a/src/tcpip.c
+++ b/src/tcpip.c
@@ -215,10 +215,14 @@ static struct tcpip_state *tcpip_state_create(void)
 static void tcpip_state_destroy(tcpip_state *sp)
 {
 #if HAVE_GNUTLS_H
+    if (sp->session)
+        gnutls_deinit(sp->session);
     tcpip_release_cred(&sp->cred_ptr);
 #endif
     if (sp->ai)
         freeaddrinfo(sp->ai);
+    xfree(sp->altbuf);
+    xfree(sp->bind_host);
     xfree(sp->host_port);
     xfree(sp->connect_host);
     wrbuf_destroy(sp->connect_request);
@@ -1146,15 +1150,13 @@ COMSTACK tcpip_accept(COMSTACK h)
             gnutls_init(&state->session, GNUTLS_SERVER);
             if (!state->session)
             {
-                tcpip_state_destroy(state);
-                xfree(cnew);
+                tcpip_close(cnew);
                 return 0;
             }
             res = gnutls_set_default_priority(state->session);
             if (res != GNUTLS_E_SUCCESS)
             {
-                tcpip_state_destroy(state);
-                xfree(cnew);
+                tcpip_close(cnew);
                 return 0;
             }
             res = gnutls_credentials_set(state->session,
@@ -1162,8 +1164,7 @@ COMSTACK tcpip_accept(COMSTACK h)
                                          st->cred_ptr->xcred);
             if (res != GNUTLS_E_SUCCESS)
             {
-                tcpip_state_destroy(state);
-                xfree(cnew);
+                tcpip_close(cnew);
                 return 0;
             }
             SET_GNUTLS_SOCKET(state->session, cnew->iofile);
@@ -1473,7 +1474,6 @@ void tcpip_close(COMSTACK h)
     tcpip_state *sp = (struct tcpip_state *)h->cprivate;
 
     yaz_log(log_level, "tcpip_close: h=%p", h);
-    xfree(sp->bind_host);
 #if RESOLVER_THREAD
     if (sp->pipefd[0] != -1)
     {
@@ -1498,14 +1498,6 @@ void tcpip_close(COMSTACK h)
         close(h->iofile);
 #endif
     }
-    if (sp->altbuf)
-        xfree(sp->altbuf);
-#if HAVE_GNUTLS_H
-    if (sp->session)
-    {
-        gnutls_deinit(sp->session);
-    }
-#endif
     tcpip_state_destroy(sp);
     xfree(h);
 }

--- a/src/tcpip.c
+++ b/src/tcpip.c
@@ -109,6 +109,7 @@ struct tcpip_cred_ptr {
     gnutls_certificate_credentials_t xcred;
     int ref;
 };
+static void tcpip_release_cred(struct tcpip_cred_ptr **ptr);
 
 #endif
 /* this state is used for both SSL and straight TCP/IP */
@@ -213,6 +214,9 @@ static struct tcpip_state *tcpip_state_create(void)
 
 static void tcpip_state_destroy(tcpip_state *sp)
 {
+#if HAVE_GNUTLS_H
+    tcpip_release_cred(&sp->cred_ptr);
+#endif
     if (sp->ai)
         freeaddrinfo(sp->ai);
     xfree(sp->host_port);
@@ -1501,7 +1505,6 @@ void tcpip_close(COMSTACK h)
     {
         gnutls_deinit(sp->session);
     }
-    tcpip_release_cred(&sp->cred_ptr);
 #endif
     tcpip_state_destroy(sp);
     xfree(h);

--- a/src/tcpip.c
+++ b/src/tcpip.c
@@ -248,6 +248,7 @@ COMSTACK tcpip_type(int s, int flags, int protocol, void *vp)
     p->event = CS_NONE;
     p->cerrno = 0;
     p->user = 0;
+    p->error_details = wrbuf_alloc();
 
     yaz_log(log_level, "Created TCP/SSL comstack h=%p", p);
 
@@ -393,7 +394,7 @@ static int ssl_check_again(COMSTACK h, tcpip_state *sp, int res)
         h->io_pending = dir ? CS_WANT_WRITE : CS_WANT_READ;
         return 1;
     }
-    h->cerrno = CSERRORSSL;
+    cs_set_error(h, CSERRORSSL, gnutls_strerror(res));
     return 0;
 }
 #endif
@@ -764,15 +765,21 @@ static int check_cert(COMSTACK h, tcpip_state *sp)
         {
             yaz_log(log_level, "TLS certificate verification error: %s",
                     gnutls_strerror(vr));
-            h->cerrno = CSERRORSSL;
+            cs_set_error(h, CSERRORSSL, gnutls_strerror(vr));
             return -1;
         }
         if (status != 0)
         {
+            char details[600];
+
             yaz_log(log_level, "TLS certificate verification failed:"
                                " status=%u host=%s",
                     status, vhost ? vhost : "");
-            h->cerrno = CSERRORSSL;
+            yaz_snprintf(details, sizeof(details),
+                         "TLS certificate verification failed:"
+                         " status=%u host=%s",
+                         status, vhost ? vhost : "");
+            cs_set_error(h, CSERRORSSL, details);
             return -1;
         }
     }
@@ -861,7 +868,7 @@ int tcpip_rcvconnect(COMSTACK h)
             if (r < 0)
             {
                 yaz_log(log_level, "gnutls_certificate_set_x509_system_trust r=%d msg=%s", r, gnutls_strerror(r));
-                h->cerrno = CSERRORSSL;
+                cs_set_error(h, CSERRORSSL, gnutls_strerror(r));
                 tcpip_release_cred(&sp->cred_ptr);
                 return -1;
             }
@@ -879,7 +886,7 @@ int tcpip_rcvconnect(COMSTACK h)
                         res,
                         gnutls_error_is_fatal(res),
                         gnutls_strerror(res));
-                h->cerrno = CSERRORSSL;
+                cs_set_error(h, CSERRORSSL, gnutls_strerror(res));
                 return -1;
             }
         }
@@ -960,7 +967,7 @@ static int tcpip_bind(COMSTACK h, void *address, int mode)
                     res,
                     gnutls_error_is_fatal(res),
                     gnutls_strerror(res));
-            h->cerrno = CSERRORSSL;
+            cs_set_error(h, CSERRORSSL, gnutls_strerror(res));
             return -1;
         }
     }
@@ -1079,6 +1086,7 @@ COMSTACK tcpip_accept(COMSTACK h)
         cnew = (COMSTACK) xmalloc(sizeof(*cnew));
 
         memcpy(cnew, h, sizeof(*h));
+        cnew->error_details = wrbuf_alloc();
         cnew->iofile = h->newfd;
         cnew->io_pending = 0;
         cnew->cprivate = state;
@@ -1096,6 +1104,7 @@ COMSTACK tcpip_accept(COMSTACK h)
                 h->newfd = -1;
             }
             xfree(state);
+            wrbuf_destroy(cnew->error_details);
             xfree(cnew);
             return 0;
         }
@@ -1113,6 +1122,7 @@ COMSTACK tcpip_accept(COMSTACK h)
             gnutls_init(&state->session, GNUTLS_SERVER);
             if (!state->session)
             {
+                wrbuf_destroy(cnew->error_details);
                 xfree(cnew);
                 xfree(state);
                 return 0;
@@ -1120,6 +1130,7 @@ COMSTACK tcpip_accept(COMSTACK h)
             res = gnutls_set_default_priority(state->session);
             if (res != GNUTLS_E_SUCCESS)
             {
+                wrbuf_destroy(cnew->error_details);
                 xfree(cnew);
                 xfree(state);
                 return 0;
@@ -1129,6 +1140,7 @@ COMSTACK tcpip_accept(COMSTACK h)
                                          st->cred_ptr->xcred);
             if (res != GNUTLS_E_SUCCESS)
             {
+                wrbuf_destroy(cnew->error_details);
                 xfree(cnew);
                 xfree(state);
                 return 0;
@@ -1481,6 +1493,7 @@ void tcpip_close(COMSTACK h)
     wrbuf_destroy(sp->connect_request);
     xfree(sp->connect_response_buf);
     xfree(sp);
+    wrbuf_destroy(h->error_details);
     xfree(h);
 }
 
@@ -1774,4 +1787,3 @@ int cs_set_head_only(COMSTACK cs, int head_only)
  * End:
  * vim: shiftwidth=4 tabstop=8 expandtab
  */
-

--- a/src/unix.c
+++ b/src/unix.c
@@ -161,6 +161,7 @@ COMSTACK unix_type(int s, int flags, int protocol, void *vp)
     p->event = CS_NONE;
     p->cerrno = 0;
     p->user = 0;
+    p->error_details = wrbuf_alloc();
 
     state->altbuf = 0;
     state->altsize = state->altlen = 0;
@@ -503,6 +504,7 @@ static COMSTACK unix_accept(COMSTACK h)
             return 0;
         }
         memcpy(cnew, h, sizeof(*h));
+        cnew->error_details = wrbuf_alloc();
         cnew->iofile = h->newfd;
         cnew->io_pending = 0;
         if (!(state = (unix_state *)
@@ -514,6 +516,8 @@ static COMSTACK unix_accept(COMSTACK h)
                 close(h->newfd);
                 h->newfd = -1;
             }
+            wrbuf_destroy(cnew->error_details);
+            xfree(cnew);
             return 0;
         }
         if (!(cnew->flags&CS_FLAGS_BLOCKING) &&
@@ -526,6 +530,7 @@ static COMSTACK unix_accept(COMSTACK h)
                 close(h->newfd);
                 h->newfd = -1;
             }
+            wrbuf_destroy(cnew->error_details);
             xfree (cnew);
             xfree (state);
             return 0;
@@ -743,6 +748,7 @@ static void unix_close(COMSTACK h)
     if (sp->altbuf)
         xfree(sp->altbuf);
     xfree(sp);
+    wrbuf_destroy(h->error_details);
     xfree(h);
 }
 
@@ -778,4 +784,3 @@ static int unix_set_blocking(COMSTACK p, int flags)
  * End:
  * vim: shiftwidth=4 tabstop=8 expandtab
  */
-

--- a/src/unix.c
+++ b/src/unix.c
@@ -102,6 +102,11 @@ static void unix_init (void)
     }
 }
 
+static void cs_set_error(COMSTACK cs, int error)
+{
+    cs->cerrno = error;
+}
+
 /*
  * This function is always called through the cs_create() macro.
  * s >= 0: socket has already been established for us.
@@ -161,7 +166,6 @@ COMSTACK unix_type(int s, int flags, int protocol, void *vp)
     p->event = CS_NONE;
     p->cerrno = 0;
     p->user = 0;
-    p->error_details = wrbuf_alloc();
 
     state->altbuf = 0;
     state->altsize = state->altlen = 0;
@@ -327,7 +331,7 @@ static int unix_connect(COMSTACK h, void *address)
     h->io_pending = 0;
     if (h->state != CS_ST_UNBND)
     {
-        cs_set_error(h, CSOUTSTATE, 0);
+        cs_set_error(h, CSOUTSTATE);
         return -1;
     }
     for (i = 0; i<3; i++)
@@ -357,7 +361,7 @@ static int unix_connect(COMSTACK h, void *address)
             h->io_pending = CS_WANT_WRITE;
             return 1;
         }
-        cs_set_error(h, CSYSERR, 0);
+        cs_set_error(h, CSYSERR);
         return -1;
     }
     h->event = CS_CONNECT;
@@ -377,7 +381,7 @@ static int unix_rcvconnect(COMSTACK h)
         return 0;
     if (h->state != CS_ST_CONNECTING)
     {
-        cs_set_error(h, CSOUTSTATE, 0);
+        cs_set_error(h, CSOUTSTATE);
         return -1;
     }
     h->event = CS_DATA;
@@ -401,13 +405,13 @@ static int unix_bind(COMSTACK h, void *address, int mode)
 
         if (!S_ISSOCK(stat_buf.st_mode))
         {
-            cs_set_error(h, CSYSERR, 0);
+            cs_set_error(h, CSYSERR);
             yaz_set_errno(EEXIST); /* Not a socket (File exists) */
             return -1;
         }
         if ((socket_out = socket(AF_UNIX, SOCK_STREAM, 0)) < 0)
         {
-            cs_set_error(h, CSYSERR, 0);
+            cs_set_error(h, CSYSERR);
             return -1;
         }
         socket_unix.sun_family = AF_UNIX;
@@ -419,14 +423,14 @@ static int unix_bind(COMSTACK h, void *address, int mode)
                 yaz_log(log_level, "unix_bind socket exists but nobody is listening");
             else
             {
-                cs_set_error(h, CSYSERR, 0);
+                cs_set_error(h, CSYSERR);
                 return -1;
             }
         }
         else
         {
             close(socket_out);
-            cs_set_error(h, CSYSERR, 0);
+            cs_set_error(h, CSYSERR);
             yaz_set_errno(EADDRINUSE);
             return -1;
         }
@@ -435,22 +439,22 @@ static int unix_bind(COMSTACK h, void *address, int mode)
 
     if (bind(h->iofile, (struct sockaddr *) addr, SUN_LEN((struct sockaddr_un *)addr)))
     {
-        cs_set_error(h, CSYSERR, 0);
+        cs_set_error(h, CSYSERR);
         return -1;
     }
     if (chown(path, sp->uid, sp->gid))
     {
-        cs_set_error(h, CSYSERR, 0);
+        cs_set_error(h, CSYSERR);
         return -1;
     }
     if (chmod(path, sp->umask != -1 ? sp->umask : 0666))
     {
-        cs_set_error(h, CSYSERR, 0);
+        cs_set_error(h, CSYSERR);
         return -1;
     }
     if (mode == CS_SERVER && listen(h->iofile, 100) < 0)
     {
-        cs_set_error(h, CSYSERR, 0);
+        cs_set_error(h, CSYSERR);
         return -1;
     }
     h->state = CS_ST_IDLE;
@@ -468,7 +472,7 @@ static int unix_listen(COMSTACK h, char *raddr, int *addrlen,
     yaz_log(log_level, "unix_listen h=%p", h);
     if (h->state != CS_ST_IDLE)
     {
-        cs_set_error(h, CSOUTSTATE, 0);
+        cs_set_error(h, CSOUTSTATE);
         return -1;
     }
     h->newfd = accept(h->iofile, (struct sockaddr*)&addr, &len);
@@ -482,9 +486,9 @@ static int unix_listen(COMSTACK h, char *raddr, int *addrlen,
 #endif
 #endif
             )
-            cs_set_error(h, CSNODATA, 0);
+            cs_set_error(h, CSNODATA);
         else
-            cs_set_error(h, CSYSERR, 0);
+            cs_set_error(h, CSYSERR);
         return -1;
     }
     if (addrlen && (size_t) (*addrlen) >= sizeof(struct sockaddr_un))
@@ -505,25 +509,23 @@ static COMSTACK unix_accept(COMSTACK h)
     {
         if (!(cnew = (COMSTACK)xmalloc(sizeof(*cnew))))
         {
-            cs_set_error(h, CSYSERR, 0);
+            cs_set_error(h, CSYSERR);
             close(h->newfd);
             h->newfd = -1;
             return 0;
         }
         memcpy(cnew, h, sizeof(*h));
-        cnew->error_details = wrbuf_alloc();
         cnew->iofile = h->newfd;
         cnew->io_pending = 0;
         if (!(state = (unix_state *)
               (cnew->cprivate = xmalloc(sizeof(unix_state)))))
         {
-            cs_set_error(h, CSYSERR, 0);
+            cs_set_error(h, CSYSERR);
             if (h->newfd != -1)
             {
                 close(h->newfd);
                 h->newfd = -1;
             }
-            wrbuf_destroy(cnew->error_details);
             xfree(cnew);
             return 0;
         }
@@ -531,13 +533,12 @@ static COMSTACK unix_accept(COMSTACK h)
             (fcntl(cnew->iofile, F_SETFL, O_NONBLOCK) < 0)
             )
         {
-            cs_set_error(h, CSYSERR, 0);
+            cs_set_error(h, CSYSERR);
             if (h->newfd != -1)
             {
                 close(h->newfd);
                 h->newfd = -1;
             }
-            wrbuf_destroy(cnew->error_details);
             xfree (cnew);
             xfree (state);
             return 0;
@@ -559,7 +560,7 @@ static COMSTACK unix_accept(COMSTACK h)
     }
     else
     {
-        cs_set_error(h, CSOUTSTATE, 0);
+        cs_set_error(h, CSOUTSTATE);
         return 0;
     }
     h->io_pending = 0;
@@ -612,12 +613,12 @@ static int unix_get(COMSTACK h, char **buf, int *bufsize)
 
             if (*bufsize - hasread < CS_UNIX_BUFCHUNK)
             {
-                cs_set_error(h, CSBUFSIZE, 0);
+                cs_set_error(h, CSBUFSIZE);
                 return -1;
             }
             if (!(*buf = (char *)xrealloc(*buf, *bufsize)))
             {
-                cs_set_error(h, CSYSERR, 0);
+                cs_set_error(h, CSYSERR);
                 return -1;
             }
         }
@@ -647,13 +648,13 @@ static int unix_get(COMSTACK h, char **buf, int *bufsize)
         hasread += res;
         if (hasread > h->max_recv_bytes)
         {
-            cs_set_error(h, CSBUFSIZE, 0);
+            cs_set_error(h, CSBUFSIZE);
             return -1;
         }
     }
     if (berlen < 0)
     {
-        cs_set_error(h, CSPROTERR, 0);
+        cs_set_error(h, CSPROTERR);
         return -1;
     }
     yaz_log(log_level, "  Out of read loop with hasread=%d, berlen=%d",
@@ -703,7 +704,7 @@ static int unix_put(COMSTACK h, char *buf, int size)
     }
     else if (state->towrite != size)
     {
-        cs_set_error(h, CSWRONGBUF, 0);
+        cs_set_error(h, CSWRONGBUF);
         return -1;
     }
     while (state->towrite > state->written)
@@ -731,7 +732,7 @@ static int unix_put(COMSTACK h, char *buf, int size)
                 h->io_pending = CS_WANT_WRITE;
                 return 1;
             }
-            cs_set_error(h, CSYSERR, 0);
+            cs_set_error(h, CSYSERR);
             return -1;
         }
         state->written += res;
@@ -755,7 +756,6 @@ static void unix_close(COMSTACK h)
     if (sp->altbuf)
         xfree(sp->altbuf);
     xfree(sp);
-    wrbuf_destroy(h->error_details);
     xfree(h);
 }
 

--- a/src/unix.c
+++ b/src/unix.c
@@ -327,7 +327,7 @@ static int unix_connect(COMSTACK h, void *address)
     h->io_pending = 0;
     if (h->state != CS_ST_UNBND)
     {
-        h->cerrno = CSOUTSTATE;
+        cs_set_error(h, CSOUTSTATE, 0);
         return -1;
     }
     for (i = 0; i<3; i++)
@@ -357,7 +357,7 @@ static int unix_connect(COMSTACK h, void *address)
             h->io_pending = CS_WANT_WRITE;
             return 1;
         }
-        h->cerrno = CSYSERR;
+        cs_set_error(h, CSYSERR, 0);
         return -1;
     }
     h->event = CS_CONNECT;
@@ -377,7 +377,7 @@ static int unix_rcvconnect(COMSTACK h)
         return 0;
     if (h->state != CS_ST_CONNECTING)
     {
-        h->cerrno = CSOUTSTATE;
+        cs_set_error(h, CSOUTSTATE, 0);
         return -1;
     }
     h->event = CS_DATA;
@@ -394,32 +394,39 @@ static int unix_bind(COMSTACK h, void *address, int mode)
 
     yaz_log(log_level, "unix_bind h=%p", h);
 
-    if (stat(path, &stat_buf) != -1) {
+    if (stat(path, &stat_buf) != -1)
+    {
         struct sockaddr_un socket_unix;
         int socket_out = -1;
 
-        if (!S_ISSOCK(stat_buf.st_mode)) {
-            h->cerrno = CSYSERR;
+        if (!S_ISSOCK(stat_buf.st_mode))
+        {
+            cs_set_error(h, CSYSERR, 0);
             yaz_set_errno(EEXIST); /* Not a socket (File exists) */
             return -1;
         }
-        if ((socket_out = socket(AF_UNIX, SOCK_STREAM, 0)) < 0) {
-            h->cerrno = CSYSERR;
+        if ((socket_out = socket(AF_UNIX, SOCK_STREAM, 0)) < 0)
+        {
+            cs_set_error(h, CSYSERR, 0);
             return -1;
         }
         socket_unix.sun_family = AF_UNIX;
         strncpy(socket_unix.sun_path, path, sizeof(socket_unix.sun_path)-1);
         socket_unix.sun_path[sizeof(socket_unix.sun_path)-1] = 0;
-        if (connect(socket_out, (struct sockaddr *) &socket_unix, SUN_LEN(&socket_unix)) < 0) {
-            if (yaz_errno() == ECONNREFUSED) {
+        if (connect(socket_out, (struct sockaddr *) &socket_unix, SUN_LEN(&socket_unix)) < 0)
+        {
+            if (yaz_errno() == ECONNREFUSED)
                 yaz_log(log_level, "unix_bind socket exists but nobody is listening");
-            } else {
-                h->cerrno = CSYSERR;
+            else
+            {
+                cs_set_error(h, CSYSERR, 0);
                 return -1;
             }
-        } else {
+        }
+        else
+        {
             close(socket_out);
-            h->cerrno = CSYSERR;
+            cs_set_error(h, CSYSERR, 0);
             yaz_set_errno(EADDRINUSE);
             return -1;
         }
@@ -428,22 +435,22 @@ static int unix_bind(COMSTACK h, void *address, int mode)
 
     if (bind(h->iofile, (struct sockaddr *) addr, SUN_LEN((struct sockaddr_un *)addr)))
     {
-        h->cerrno = CSYSERR;
+        cs_set_error(h, CSYSERR, 0);
         return -1;
     }
     if (chown(path, sp->uid, sp->gid))
     {
-        h->cerrno = CSYSERR;
+        cs_set_error(h, CSYSERR, 0);
         return -1;
     }
     if (chmod(path, sp->umask != -1 ? sp->umask : 0666))
     {
-        h->cerrno = CSYSERR;
+        cs_set_error(h, CSYSERR, 0);
         return -1;
     }
     if (mode == CS_SERVER && listen(h->iofile, 100) < 0)
     {
-        h->cerrno = CSYSERR;
+        cs_set_error(h, CSYSERR, 0);
         return -1;
     }
     h->state = CS_ST_IDLE;
@@ -461,7 +468,7 @@ static int unix_listen(COMSTACK h, char *raddr, int *addrlen,
     yaz_log(log_level, "unix_listen h=%p", h);
     if (h->state != CS_ST_IDLE)
     {
-        h->cerrno = CSOUTSTATE;
+        cs_set_error(h, CSOUTSTATE, 0);
         return -1;
     }
     h->newfd = accept(h->iofile, (struct sockaddr*)&addr, &len);
@@ -475,9 +482,9 @@ static int unix_listen(COMSTACK h, char *raddr, int *addrlen,
 #endif
 #endif
             )
-            h->cerrno = CSNODATA;
+            cs_set_error(h, CSNODATA, 0);
         else
-            h->cerrno = CSYSERR;
+            cs_set_error(h, CSYSERR, 0);
         return -1;
     }
     if (addrlen && (size_t) (*addrlen) >= sizeof(struct sockaddr_un))
@@ -498,7 +505,7 @@ static COMSTACK unix_accept(COMSTACK h)
     {
         if (!(cnew = (COMSTACK)xmalloc(sizeof(*cnew))))
         {
-            h->cerrno = CSYSERR;
+            cs_set_error(h, CSYSERR, 0);
             close(h->newfd);
             h->newfd = -1;
             return 0;
@@ -510,7 +517,7 @@ static COMSTACK unix_accept(COMSTACK h)
         if (!(state = (unix_state *)
               (cnew->cprivate = xmalloc(sizeof(unix_state)))))
         {
-            h->cerrno = CSYSERR;
+            cs_set_error(h, CSYSERR, 0);
             if (h->newfd != -1)
             {
                 close(h->newfd);
@@ -524,7 +531,7 @@ static COMSTACK unix_accept(COMSTACK h)
             (fcntl(cnew->iofile, F_SETFL, O_NONBLOCK) < 0)
             )
         {
-            h->cerrno = CSYSERR;
+            cs_set_error(h, CSYSERR, 0);
             if (h->newfd != -1)
             {
                 close(h->newfd);
@@ -552,7 +559,7 @@ static COMSTACK unix_accept(COMSTACK h)
     }
     else
     {
-        h->cerrno = CSOUTSTATE;
+        cs_set_error(h, CSOUTSTATE, 0);
         return 0;
     }
     h->io_pending = 0;
@@ -605,12 +612,12 @@ static int unix_get(COMSTACK h, char **buf, int *bufsize)
 
             if (*bufsize - hasread < CS_UNIX_BUFCHUNK)
             {
-                h->cerrno = CSBUFSIZE;
+                cs_set_error(h, CSBUFSIZE, 0);
                 return -1;
             }
             if (!(*buf = (char *)xrealloc(*buf, *bufsize)))
             {
-                h->cerrno = CSYSERR;
+                cs_set_error(h, CSYSERR, 0);
                 return -1;
             }
         }
@@ -640,13 +647,13 @@ static int unix_get(COMSTACK h, char **buf, int *bufsize)
         hasread += res;
         if (hasread > h->max_recv_bytes)
         {
-            h->cerrno = CSBUFSIZE;
+            cs_set_error(h, CSBUFSIZE, 0);
             return -1;
         }
     }
     if (berlen < 0)
     {
-        h->cerrno = CSPROTERR;
+        cs_set_error(h, CSPROTERR, 0);
         return -1;
     }
     yaz_log(log_level, "  Out of read loop with hasread=%d, berlen=%d",
@@ -696,7 +703,7 @@ static int unix_put(COMSTACK h, char *buf, int size)
     }
     else if (state->towrite != size)
     {
-        h->cerrno = CSWRONGBUF;
+        cs_set_error(h, CSWRONGBUF, 0);
         return -1;
     }
     while (state->towrite > state->written)
@@ -724,7 +731,7 @@ static int unix_put(COMSTACK h, char *buf, int size)
                 h->io_pending = CS_WANT_WRITE;
                 return 1;
             }
-            h->cerrno = CSYSERR;
+            cs_set_error(h, CSYSERR, 0);
             return -1;
         }
         state->written += res;

--- a/src/url.c
+++ b/src/url.c
@@ -147,6 +147,15 @@ static void log_warn(yaz_url_t p)
     yaz_log(YLOG_WARN, "yaz_url: %s", wrbuf_cstr(p->w_error));
 }
 
+static void add_comstack_details(yaz_url_t p, COMSTACK conn)
+{
+    const char *details;
+    int code = cs_get_error(conn, &details);
+    wrbuf_printf(p->w_error, ": cs=%d msg=%s", code, cs_errmsg(code));
+    if (details)
+        wrbuf_printf(p->w_error, " details=%s", details);
+}
+
 Z_HTTP_Response *yaz_url_exec(yaz_url_t p, const char *uri,
                               const char *method,
                               Z_HTTP_Header *user_headers,
@@ -218,6 +227,7 @@ Z_HTTP_Response *yaz_url_exec(yaz_url_t p, const char *uri,
         else if ((ret = cs_connect(conn, add)) < 0)
         {
             wrbuf_printf(p->w_error, "Can not connect to URL %s", uri);
+            add_comstack_details(p, conn);
             log_warn(p);
         }
         else
@@ -263,8 +273,8 @@ Z_HTTP_Response *yaz_url_exec(yaz_url_t p, const char *uri,
                     ret = cs_rcvconnect(conn);
                     if (ret < 0)
                     {
-                        wrbuf_printf(p->w_error,
-                                     "cs_rcvconnect failed for URL %s", uri);
+                        wrbuf_printf(p->w_error, "cs_rcvconnect failed for URL %s", uri);
+                        add_comstack_details(p, conn);
                         log_warn(p);
                         break;
                     }
@@ -277,6 +287,7 @@ Z_HTTP_Response *yaz_url_exec(yaz_url_t p, const char *uri,
                     if (ret < 0)
                     {
                         wrbuf_printf(p->w_error, "cs_put fail for URL %s", uri);
+                        add_comstack_details(p, conn);
                         log_warn(p);
                         break;
                     }
@@ -288,10 +299,18 @@ Z_HTTP_Response *yaz_url_exec(yaz_url_t p, const char *uri,
                 else if (state == 2) /* read response phase */
                 {
                     ret = cs_get(conn, &netbuffer, &netlen);
-                    if (ret  <= 0)
+                    if (ret <= 0)
                     {
-                        wrbuf_printf(p->w_error, "cs_get failed for URL %s",
-                                     uri);
+                        if (ret < 0)
+                        {
+                            wrbuf_printf(p->w_error,
+                                         "cs_get failed for URL %s", uri);
+                            add_comstack_details(p, conn);
+                        }
+                        else
+                            wrbuf_printf(p->w_error,
+                                         "Connection closed while reading"
+                                         " URL %s", uri);
                         log_warn(p);
                         break;
                     }
@@ -349,4 +368,3 @@ Z_HTTP_Response *yaz_url_exec(yaz_url_t p, const char *uri,
  * End:
  * vim: shiftwidth=4 tabstop=8 expandtab
  */
-

--- a/src/yaz/comstack.h
+++ b/src/yaz/comstack.h
@@ -35,6 +35,7 @@
 
 #include <yaz/yconfig.h>
 #include <yaz/oid_util.h>
+#include <yaz/wrbuf.h>
 #include <yaz/xmalloc.h>
 
 YAZ_BEGIN_CDECL
@@ -85,6 +86,7 @@ struct comstack
     void *(*f_straddr)(COMSTACK handle, const char *str);
     int (*f_set_blocking)(COMSTACK handle, int blocking);
     void *user;       /* user defined data associated with COMSTACK */
+    WRBUF error_details; /* additional information for the current error */
 };
 
 #define cs_put(handle, buf, size) ((*(handle)->f_put)(handle, buf, size))
@@ -117,6 +119,18 @@ struct comstack
 YAZ_EXPORT int cs_look (COMSTACK);
 YAZ_EXPORT const char *cs_strerror(COMSTACK h);
 YAZ_EXPORT const char *cs_errmsg(int n);
+/** \brief returns COMSTACK error and additional information
+    \param cs COMSTACK handle
+    \param details additional error information (result), or NULL
+    \returns error code
+ */
+YAZ_EXPORT int cs_get_error(COMSTACK cs, const char **details);
+/** \brief sets COMSTACK error and additional information
+    \param cs COMSTACK handle
+    \param error error code
+    \param details additional error information, or NULL
+ */
+YAZ_EXPORT void cs_set_error(COMSTACK cs, int error, const char *details);
 YAZ_EXPORT COMSTACK cs_create_host(const char *type_and_host,
                                    int blocking, void **vp);
 
@@ -181,4 +195,3 @@ YAZ_END_CDECL
  * End:
  * vim: shiftwidth=4 tabstop=8 expandtab
  */
-

--- a/src/yaz/comstack.h
+++ b/src/yaz/comstack.h
@@ -35,7 +35,6 @@
 
 #include <yaz/yconfig.h>
 #include <yaz/oid_util.h>
-#include <yaz/wrbuf.h>
 #include <yaz/xmalloc.h>
 
 YAZ_BEGIN_CDECL
@@ -86,7 +85,6 @@ struct comstack
     void *(*f_straddr)(COMSTACK handle, const char *str);
     int (*f_set_blocking)(COMSTACK handle, int blocking);
     void *user;       /* user defined data associated with COMSTACK */
-    WRBUF error_details; /* additional information for the current error */
 };
 
 #define cs_put(handle, buf, size) ((*(handle)->f_put)(handle, buf, size))
@@ -125,12 +123,6 @@ YAZ_EXPORT const char *cs_errmsg(int n);
     \returns error code
  */
 YAZ_EXPORT int cs_get_error(COMSTACK cs, const char **details);
-/** \brief sets COMSTACK error and additional information
-    \param cs COMSTACK handle
-    \param error error code
-    \param details additional error information, or NULL
- */
-YAZ_EXPORT void cs_set_error(COMSTACK cs, int error, const char *details);
 YAZ_EXPORT COMSTACK cs_create_host(const char *type_and_host,
                                    int blocking, void **vp);
 

--- a/test/test_comstack.c
+++ b/test/test_comstack.c
@@ -474,14 +474,22 @@ static void tst_cs_error(void)
     YAZ_CHECK_EQ(cs_get_error(cs, &details), CSNONE);
     YAZ_CHECK(!details);
 
-    cs_set_error(cs, CSERRORSSL, "certificate verification failed");
-    YAZ_CHECK_EQ(cs_get_error(cs, 0), CSERRORSSL);
-    YAZ_CHECK_EQ(cs_get_error(cs, &details), CSERRORSSL);
-    YAZ_CHECK(details && !strcmp(details, "certificate verification failed"));
+#if HAVE_GNUTLS_H
+    {
+        COMSTACK ssl_cs =
+            cs_create(ssl_type, CS_FLAGS_BLOCKING, PROTO_Z3950);
 
-    cs_set_error(cs, CSNONE, 0);
-    YAZ_CHECK_EQ(cs_get_error(cs, &details), CSNONE);
-    YAZ_CHECK(!details);
+        YAZ_CHECK(ssl_cs);
+        if (ssl_cs)
+        {
+            YAZ_CHECK(cs_set_ssl_certificate_file(ssl_cs, ""));
+            YAZ_CHECK_EQ(cs_bind(ssl_cs, 0, CS_SERVER), -1);
+            YAZ_CHECK_EQ(cs_get_error(ssl_cs, &details), CSERRORSSL);
+            YAZ_CHECK(details && *details);
+            cs_close(ssl_cs);
+        }
+    }
+#endif
 
     cs_close(cs);
 }
@@ -495,7 +503,7 @@ int main (int argc, char **argv)
     tst_http_request();
     tst_http_response();
     tst_cs_get_host_args();
-    tst_cs_error();
+    tst_cs_get_error();
     YAZ_CHECK_TERM;
 }
 

--- a/test/test_comstack.c
+++ b/test/test_comstack.c
@@ -462,7 +462,7 @@ static void tst_cs_get_host_args(void)
     YAZ_CHECK(arg && !strcmp(arg, "x"));
 }
 
-static void tst_cs_error(void)
+static void tst_cs_get_error(void)
 {
     COMSTACK cs = cs_create(tcpip_type, CS_FLAGS_BLOCKING, PROTO_Z3950);
     const char *details = "not set";

--- a/test/test_comstack.c
+++ b/test/test_comstack.c
@@ -482,8 +482,11 @@ static void tst_cs_get_error(void)
         YAZ_CHECK(ssl_cs);
         if (ssl_cs)
         {
+            void *ad = cs_straddr(ssl_cs, "localhost:0");
+            YAZ_CHECK(ad);
             YAZ_CHECK(cs_set_ssl_certificate_file(ssl_cs, ""));
-            YAZ_CHECK_EQ(cs_bind(ssl_cs, 0, CS_SERVER), -1);
+            if (ad)
+                 YAZ_CHECK_EQ(cs_bind(ssl_cs, ad, CS_SERVER), -1);
             YAZ_CHECK_EQ(cs_get_error(ssl_cs, &details), CSERRORSSL);
             YAZ_CHECK(details && *details);
             cs_close(ssl_cs);

--- a/test/test_comstack.c
+++ b/test/test_comstack.c
@@ -486,9 +486,11 @@ static void tst_cs_get_error(void)
             YAZ_CHECK(ad);
             YAZ_CHECK(cs_set_ssl_certificate_file(ssl_cs, ""));
             if (ad)
-                 YAZ_CHECK_EQ(cs_bind(ssl_cs, ad, CS_SERVER), -1);
-            YAZ_CHECK_EQ(cs_get_error(ssl_cs, &details), CSERRORSSL);
-            YAZ_CHECK(details && *details);
+            {
+                YAZ_CHECK_EQ(cs_bind(ssl_cs, ad, CS_SERVER), -1);
+                YAZ_CHECK_EQ(cs_get_error(ssl_cs, &details), CSERRORSSL);
+                YAZ_CHECK(details && *details);
+            }
             cs_close(ssl_cs);
         }
     }

--- a/test/test_comstack.c
+++ b/test/test_comstack.c
@@ -462,6 +462,30 @@ static void tst_cs_get_host_args(void)
     YAZ_CHECK(arg && !strcmp(arg, "x"));
 }
 
+static void tst_cs_error(void)
+{
+    COMSTACK cs = cs_create(tcpip_type, CS_FLAGS_BLOCKING, PROTO_Z3950);
+    const char *details = "not set";
+
+    YAZ_CHECK(cs);
+    if (!cs)
+        return;
+
+    YAZ_CHECK_EQ(cs_get_error(cs, &details), CSNONE);
+    YAZ_CHECK(!details);
+
+    cs_set_error(cs, CSERRORSSL, "certificate verification failed");
+    YAZ_CHECK_EQ(cs_get_error(cs, 0), CSERRORSSL);
+    YAZ_CHECK_EQ(cs_get_error(cs, &details), CSERRORSSL);
+    YAZ_CHECK(details && !strcmp(details, "certificate verification failed"));
+
+    cs_set_error(cs, CSNONE, 0);
+    YAZ_CHECK_EQ(cs_get_error(cs, &details), CSNONE);
+    YAZ_CHECK(!details);
+
+    cs_close(cs);
+}
+
 int main (int argc, char **argv)
 {
     YAZ_CHECK_INIT(argc, argv);
@@ -471,6 +495,7 @@ int main (int argc, char **argv)
     tst_http_request();
     tst_http_response();
     tst_cs_get_host_args();
+    tst_cs_error();
     YAZ_CHECK_TERM;
 }
 
@@ -482,4 +507,3 @@ int main (int argc, char **argv)
  * End:
  * vim: shiftwidth=4 tabstop=8 expandtab
  */
-


### PR DESCRIPTION
Provides error details for COMSTACK failures. This is, especially, useful for SSL failures.